### PR TITLE
refact: use Bento FastAPI base class + remove redundant code

### DIFF
--- a/bento_drop_box_service/app.py
+++ b/bento_drop_box_service/app.py
@@ -1,11 +1,10 @@
-from bento_lib.responses.fastapi_errors import http_exception_handler_factory, validation_exception_handler_factory
-from fastapi import FastAPI
-from fastapi.exceptions import RequestValidationError
-from fastapi.middleware.cors import CORSMiddleware
-from starlette.exceptions import HTTPException as StarletteHTTPException
+from bento_lib.apps.fastapi import BentoFastAPI
+from bento_lib.service_info.types import BentoExtraServiceInfo
 
+from . import __version__
 from .authz import authz_middleware
 from .config import get_config
+from .constants import BENTO_SERVICE_KIND, SERVICE_TYPE
 from .logger import get_logger
 from .routes import drop_box_router
 
@@ -14,23 +13,15 @@ __all__ = [
 ]
 
 
-application = FastAPI()
-application.include_router(drop_box_router)
+BENTO_SERVICE_INFO: BentoExtraServiceInfo = {
+    "serviceKind": BENTO_SERVICE_KIND,
+    "gitRepository": "https://github.com/bento-platform/bento_drop_box_service",
+}
 
 # TODO: Find a way to DI this
 config_for_setup = get_config()
 
-application.add_middleware(
-    CORSMiddleware,
-    allow_origins=config_for_setup.cors_origins,
-    allow_headers=["Authorization"],
-    allow_credentials=True,
-    allow_methods=["*"],
+application = BentoFastAPI(
+    authz_middleware, config_for_setup, get_logger(config_for_setup), BENTO_SERVICE_INFO, SERVICE_TYPE, __version__
 )
-
-# Non-standard middleware setup so that we can import the instance and use it for dependencies too
-authz_middleware.attach(application)
-
-application.exception_handler(StarletteHTTPException)(
-    http_exception_handler_factory(get_logger(config_for_setup), authz_middleware))
-application.exception_handler(RequestValidationError)(validation_exception_handler_factory(authz_middleware))
+application.include_router(drop_box_router)

--- a/bento_drop_box_service/authz.py
+++ b/bento_drop_box_service/authz.py
@@ -1,5 +1,6 @@
 from bento_lib.auth.middleware.fastapi import FastApiAuthMiddleware
 from .config import get_config
+from .logger import get_logger
 
 __all__ = [
     "authz_middleware",
@@ -8,10 +9,5 @@ __all__ = [
 # TODO: Find a way to DI this
 config = get_config()
 
-
 # Non-standard middleware setup so that we can import the instance and use it for dependencies too
-authz_middleware = FastApiAuthMiddleware(
-    config.bento_authz_service_url,
-    debug_mode=config.bento_debug,
-    enabled=config.authz_enabled,
-)
+authz_middleware = FastApiAuthMiddleware.build_from_pydantic_config(config, get_logger(config))

--- a/bento_drop_box_service/backends/local.py
+++ b/bento_drop_box_service/backends/local.py
@@ -48,7 +48,7 @@ class LocalBackend(DropBoxBackend):
                         "size": entry_path_stat.st_size,
                         "lastModified": entry_path_stat.st_mtime,
                         "lastMetadataChange": entry_path_stat.st_ctime,
-                        "uri": self.config.service_url + f"/objects{rel_path}",
+                        "uri": self.config.service_url_base_path + f"/objects{rel_path}",
                     })
                 })
 

--- a/bento_drop_box_service/config.py
+++ b/bento_drop_box_service/config.py
@@ -1,4 +1,4 @@
-from bento_lib.config.pydantic import BentoBaseConfig
+from bento_lib.config.pydantic import BentoFastAPIBaseConfig
 from fastapi import Depends
 from functools import lru_cache
 from typing import Annotated, Literal
@@ -12,17 +12,14 @@ __all__ = [
 ]
 
 
-class Config(BentoBaseConfig):
+class Config(BentoFastAPIBaseConfig):
     service_id: str = str(":".join(list(SERVICE_TYPE.values())[:2]))
     service_name: str = "Bento Drop Box Service"
     service_description: str = "Drop box service for a Bento platform node."
-    service_url: str = "http://127.0.0.1:5000"  # base URL to construct object URIs from
 
     service_data: str = "data/"
     service_data_source: Literal["local"] = "local"
     traversal_limit: int = 16
-
-    authz_enabled: bool = True
 
 
 @lru_cache()

--- a/bento_drop_box_service/constants.py
+++ b/bento_drop_box_service/constants.py
@@ -1,3 +1,4 @@
+from bento_lib.service_info.helpers import build_bento_service_type
 from bento_lib.service_info.types import GA4GHServiceType
 from bento_drop_box_service import __version__
 
@@ -7,8 +8,4 @@ __all__ = [
 ]
 
 BENTO_SERVICE_KIND = "drop-box"
-SERVICE_TYPE: GA4GHServiceType = {
-    "group": "ca.c3g.bento",
-    "artifact": BENTO_SERVICE_KIND,
-    "version": __version__,
-}
+SERVICE_TYPE: GA4GHServiceType = build_bento_service_type(BENTO_SERVICE_KIND, __version__)

--- a/bento_drop_box_service/routes.py
+++ b/bento_drop_box_service/routes.py
@@ -1,18 +1,13 @@
 from bento_lib.auth.permissions import P_VIEW_DROP_BOX, P_INGEST_DROP_BOX, P_DELETE_DROP_BOX
 from bento_lib.auth.resources import RESOURCE_EVERYTHING
-from bento_lib.service_info.helpers import build_service_info_from_pydantic_config
 from fastapi import APIRouter, Form, Request, status
 from fastapi.exceptions import HTTPException
 from fastapi.responses import JSONResponse
 from starlette.responses import Response
 from typing import Annotated
 
-from . import __version__
 from .authz import authz_middleware
 from .backends.dependency import BackendDependency
-from .constants import BENTO_SERVICE_KIND, SERVICE_TYPE
-from .config import ConfigDependency
-from .logger import LoggerDependency
 
 
 drop_box_router = APIRouter()
@@ -69,18 +64,3 @@ async def drop_box_upload(request: Request, path: str, backend: BackendDependenc
 )
 async def drop_box_delete(path: str, backend: BackendDependency):
     return await backend.delete_at_path(path)
-
-
-@drop_box_router.get("/service-info", dependencies=[authz_middleware.dep_public_endpoint()])
-async def service_info(config: ConfigDependency, logger: LoggerDependency) -> Response:
-    # Spec: https://github.com/ga4gh-discovery/ga4gh-service-info
-    return JSONResponse(await build_service_info_from_pydantic_config(
-        config,
-        logger,
-        {
-            "serviceKind": BENTO_SERVICE_KIND,
-            "gitRepository": "https://github.com/bento-platform/bento_drop_box_service",
-        },
-        SERVICE_TYPE,
-        __version__,
-    ))

--- a/poetry.lock
+++ b/poetry.lock
@@ -2360,4 +2360,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10.0"
-content-hash = "98f67448aae3b18398bae7594fe764b907a75bbab2bf6a8597f4e1952e82e96a"
+content-hash = "0d351af03a89bfbdbb0e65428ed8078bc495d98af624286db426b9b7500c13d6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "bento_drop_box_service"
-version = "1.1.6"
+version = "1.1.7"
 description = "Drop box and basic file management service for the Bento platform."
 authors = ["David Lougheed <david.lougheed@mail.mcgill.ca>", "Simon Chénard <simon.chenard2@mcgill.ca>"]
 readme = "README.md"
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.10.0"
-bento-lib = {extras = ["fastapi"], version = "^11.10.0"}
+bento-lib = {extras = ["fastapi"], version = "^11.10.1"}
 aiofiles = "^23.2.1"
 fastapi = "^0.111.0"
 werkzeug = "^3.0.3"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ bucket_name = "test"
 @lru_cache
 def get_test_local_config():
     os.environ["BENTO_DEBUG"] = "True"
-    os.environ["AUTHZ_ENABLED"] = "False"
+    os.environ["BENTO_AUTHZ_ENABLED"] = "False"
     os.environ["CORS_ORIGINS"] = "*"
     os.environ["SERVICE_DATA"] = local_dir
     os.environ["BENTO_AUTHZ_SERVICE_URL"] = "https://skip"


### PR DESCRIPTION
requires changing SERVICE_URL env to SERVICE_URL_BASE_PATH and AUTHZ_ENABLED to BENTO_AUTHZ_ENABLED